### PR TITLE
Add full offline support for all Minecraft loaders and local test data exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test/Minecraft
 test/*.json*
 webfiles/instances/*
 .DS_Store
+Minecraft
+account.json

--- a/package.json
+++ b/package.json
@@ -1,60 +1,60 @@
 {
-    "name": "minecraft-java-core",
-    "version": "4.0.1",
-    "types": "./build/Index.d.ts",
-    "exports": {
-        ".": {
-            "import": "./build/Index.js",
-            "require": "./build/Index.js"
-        }
-    },
-    "description": "A library starting minecraft game NW.js and Electron.js",
-    "scripts": {
-        "dev": "rimraf ./build && tsc -w",
-        "build": "rimraf ./build && tsc",
-        "prepublishOnly": "npm i && npm run build"
-    },
-    "engines": {
-        "node": ">=18.0.0"
-    },
-    "files": [
-        "assets/**",
-        "build/**",
-        "LICENSE",
-        "README.md"
-    ],
-    "keywords": [
-        "Minecraft",
-        "Launcher",
-        "Node-Minecraft",
-        "Game",
-        "Minecraft-Launcher",
-        "Forge",
-        "Minecraft-Forge"
-    ],
-    "author": "Luuxis",
-    "license": "CCANC",
-    "dependencies": {
-        "7zip-bin": "^5.2.0",
-        "adm-zip": "^0.5.16",
-        "node-7z": "^3.0.0",
-        "prompt": "^1.3.0",
-        "tslib": "^2.8.1"
-    },
-    "devDependencies": {
-        "@types/adm-zip": "^0.5.7",
-        "@types/node": "^22.10.2",
-        "@types/node-7z": "^2.1.10",
-        "@types/node-fetch": "^2.6.12",
-        "rimraf": "^6.0.1",
-        "typescript": "^5.7.2"
-    },
-    "bugs": {
-        "url": "https://github.com/luuxis/minecraft-java-core/issues"
-    },
-    "homepage": "https://github.com/luuxis/minecraft-java-core#readme",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/luuxis/minecraft-java-core.git"
+  "name": "minecraft-java-core",
+  "version": "4.0.2",
+  "types": "./build/Index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./build/Index.js",
+      "require": "./build/Index.js"
     }
+  },
+  "description": "A library starting minecraft game NW.js and Electron.js",
+  "scripts": {
+    "dev": "rimraf ./build && tsc -w",
+    "build": "rimraf ./build && tsc",
+    "prepublishOnly": "npm i && npm run build"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "files": [
+    "assets/**",
+    "build/**",
+    "LICENSE",
+    "README.md"
+  ],
+  "keywords": [
+    "Minecraft",
+    "Launcher",
+    "Node-Minecraft",
+    "Game",
+    "Minecraft-Launcher",
+    "Forge",
+    "Minecraft-Forge"
+  ],
+  "author": "Luuxis",
+  "license": "CCANC",
+  "dependencies": {
+    "7zip-bin": "^5.2.0",
+    "adm-zip": "^0.5.16",
+    "node-7z": "^3.0.0",
+    "prompt": "^1.3.0",
+    "tslib": "^2.8.1"
+  },
+  "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
+    "@types/node": "^22.10.2",
+    "@types/node-7z": "^2.1.10",
+    "@types/node-fetch": "^2.6.12",
+    "rimraf": "^6.0.1",
+    "typescript": "^5.7.2"
+  },
+  "bugs": {
+    "url": "https://github.com/luuxis/minecraft-java-core/issues"
+  },
+  "homepage": "https://github.com/luuxis/minecraft-java-core#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/luuxis/minecraft-java-core.git"
+  }
 }

--- a/src/Minecraft-Loader/loader/neoForge/neoForge.ts
+++ b/src/Minecraft-Loader/loader/neoForge/neoForge.ts
@@ -102,9 +102,24 @@ export default class NeoForgeMC extends EventEmitter {
 		let neoForgeURL: string;
 		let oldAPI = true;
 
-		// Fetch versions from the legacy API
-		const legacyMetaData = await fetch(Loader.legacyMetaData).then(res => res.json());
-		const metaData = await fetch(Loader.metaData).then(res => res.json());
+		// Try to fetch metadata from online source first, then fallback to local cache
+		const metaPath = path.join(this.options.path, 'mc-assets', 'neoforge-meta.json');
+		let legacyMetaData;
+		let metaData;
+
+		try {
+			const legacyResponse = await fetch(Loader.legacyMetaData);
+			legacyMetaData = await legacyResponse.json();
+			const metaResponse = await fetch(Loader.metaData);
+			metaData = await metaResponse.json();
+			fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+			fs.writeFileSync(metaPath, JSON.stringify({ legacy: legacyMetaData, meta: metaData }, null, 4));
+		} catch (error) {
+			// Fetch failed; attempt loading from local cache
+			const cachedData = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+			legacyMetaData = cachedData.legacy;
+			metaData = cachedData.meta;
+		}
 
 		// Filter versions for the specified Minecraft version
 		let versions: string[] = legacyMetaData.versions.filter((v: string) =>

--- a/src/Minecraft-Loader/loader/quilt/quilt.ts
+++ b/src/Minecraft-Loader/loader/quilt/quilt.ts
@@ -87,9 +87,22 @@ export default class Quilt extends EventEmitter {
 	public async downloadJson(Loader: LoaderObject): Promise<QuiltJSON | { error: string }> {
 		let selectedBuild: any;
 
-		// Fetch the metadata
-		const metaResponse = await fetch(Loader.metaData);
-		const metaData = await metaResponse.json();
+		const metaPath = path.join(this.options.path, 'mc-assets', 'quilt-meta.json');
+		let metaData;
+
+		// Try to fetch metadata from online source first, then fallback to local cache
+		try {
+			const response = await fetch(Loader.metaData);
+			metaData = await response.json();
+			fs.mkdirSync(path.dirname(metaPath), { recursive: true });
+			fs.writeFileSync(metaPath, JSON.stringify(metaData, null, 4));
+		} catch (error) {
+			// Fetch failed; attempt loading from local cache
+			if (!fs.existsSync(metaPath)) {
+				return { error: "No cached metadata available and unable to fetch from network" };
+			}
+			metaData = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
+		}
 
 		// Check if the requested Minecraft version is supported
 		const mcVersionExists = metaData.game.find((ver: any) => ver.version === this.options.loader.version);


### PR DESCRIPTION
### 🛠 Added Full Offline Support for Minecraft Loaders

This PR implements a complete offline mode system for all major Minecraft loaders:

* ✅ **Vanilla (Minecraft-Json.ts)**
* ✅ **Fabric**
* ✅ **Forge**
* ✅ **NeoForge**
* ✅ **Quilt**
* ✅ **LegacyFabric**

All remote metadata (e.g., `version_manifest.json`, loader profiles, Forge promotions, etc.) is now cached locally under the `mc-assets` folder upon first download. If the user is offline, the system automatically loads the cached files, allowing the game to launch without an internet connection.

### 📁 Also updated `.gitignore`

* Ignored the local `Minecraft/` folder used for testing the launcher.
* Ignored `account.json`, a temporary account file generated for test sessions.

This makes development cleaner and safer by excluding local user data from version control.
