### PR TITLE
docs: fix README TypeScript example for Microsoft.getAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ import { Launch, Microsoft } from 'minecraft-java-core';
 
 // ⚠️  In production, perform auth **before** initialising the launcher
 //     so you can handle refresh / error flows cleanly.
-const auth = await Microsoft.auth({
-  client_id: '00000000-0000-0000-0000-000000000000',
-  type: 'terminal' // 'electron' | 'nwjs'
-});
+const auth = await new Microsoft('00000000-0000-0000-0000-000000000000').getAuth('terminal'); // 'electron' | 'nwjs'
 
 const launcher = new Launch();
 


### PR DESCRIPTION
This update straightens out the “Standard Example (ESM)” snippet so newcomers can copy-paste it and launch the game without surprises.

#### What changed
* **Pass `client_id` to the constructor** – `new Microsoft('<client_id>')`.
* **Call `getAuth('terminal')`** (or `'electron' | 'nwjs'`) instead of feeding it an object it can’t parse.
* Left every original comment and the rest of the code untouched so the diff is minimal and familiar.

#### Why
The previous sample looked fine at a glance but silently returned `false`, causing the launcher to run offline (or just error). This tweak matches the actual method signature and works out-of-the-box on Node 18+ / TS 5.

No library code changes, just docs.